### PR TITLE
Fix bugs for Date, Salary, Experience

### DIFF
--- a/src/main/java/seedu/address/model/information/Date.java
+++ b/src/main/java/seedu/address/model/information/Date.java
@@ -15,7 +15,7 @@ import java.time.format.ResolverStyle;
 public class Date {
 
     public static final String DATE_FORMAT = "d-M-uu"; // eg. 31-12-20
-    public static final String MESSAGE_CONSTRAINTS = "Dates must be of the format DD-MM-YY. Day and Month can be "
+    public static final String MESSAGE_CONSTRAINTS = "Dates must be of the format DD-MM-YY where Day and Month can be "
             + "1 or 2 digits as long as they are valid, eg. 1-12-20";
     public static final DateTimeFormatter DATE_FORMATTER =
             DateTimeFormatter.ofPattern(DATE_FORMAT).withResolverStyle(ResolverStyle.STRICT);

--- a/src/main/java/seedu/address/model/information/Date.java
+++ b/src/main/java/seedu/address/model/information/Date.java
@@ -15,7 +15,7 @@ public class Date {
 
     public static final String DATE_FORMAT = "d-M-yy"; // eg. 31-12-20
     public static final String MESSAGE_CONSTRAINTS = String.format("Dates must be of the format %s ,"
-                    + " eg. 12-31-20", DATE_FORMAT);
+                    + " eg. 31-12-20", DATE_FORMAT);
     public static final DateTimeFormatter DATE_FORMATTER =
             DateTimeFormatter.ofPattern(DATE_FORMAT);
 

--- a/src/main/java/seedu/address/model/information/Date.java
+++ b/src/main/java/seedu/address/model/information/Date.java
@@ -16,7 +16,7 @@ public class Date {
 
     public static final String DATE_FORMAT = "d-M-uu"; // eg. 31-12-20
     public static final String MESSAGE_CONSTRAINTS = "Dates must be of the format DD-MM-YY where Day and Month can be "
-            + "1 or 2 digits as long as they are valid, eg. 1-12-20";
+            + "1 or more digits as long as they are valid, eg. 1-12-20";
     public static final DateTimeFormatter DATE_FORMATTER =
             DateTimeFormatter.ofPattern(DATE_FORMAT).withResolverStyle(ResolverStyle.STRICT);
 

--- a/src/main/java/seedu/address/model/information/Date.java
+++ b/src/main/java/seedu/address/model/information/Date.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents a Person's date of application for a job.
@@ -13,11 +14,11 @@ import java.time.format.DateTimeFormatter;
  */
 public class Date {
 
-    public static final String DATE_FORMAT = "d-M-yy"; // eg. 31-12-20
-    public static final String MESSAGE_CONSTRAINTS = String.format("Dates must be of the format %s ,"
-                    + " eg. 31-12-20", DATE_FORMAT);
+    public static final String DATE_FORMAT = "d-M-uu"; // eg. 31-12-20
+    public static final String MESSAGE_CONSTRAINTS = "Dates must be of the format DD-MM-YY. Day and Month can be "
+            + "1 or 2 digits as long as they are valid, eg. 1-12-20";
     public static final DateTimeFormatter DATE_FORMATTER =
-            DateTimeFormatter.ofPattern(DATE_FORMAT);
+            DateTimeFormatter.ofPattern(DATE_FORMAT).withResolverStyle(ResolverStyle.STRICT);
 
     public final LocalDate date;
     public final String dateString;

--- a/src/main/java/seedu/address/model/information/Experience.java
+++ b/src/main/java/seedu/address/model/information/Experience.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Experience {
 
     public static final String MESSAGE_CONSTRAINTS = "Experience in years has to be an unsigned (non-negative) number "
-            + "that is less than 101 (max of 100).";
+            + "that is less than or equals to 100.";
 
     public final double experienceInYears;
 
@@ -37,7 +37,7 @@ public class Experience {
         } catch (NumberFormatException exception) {
             return false;
         }
-        return experience >= 0 && experience < 101;
+        return experience >= 0 && experience <= 100;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/information/Experience.java
+++ b/src/main/java/seedu/address/model/information/Experience.java
@@ -9,10 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Experience {
 
-    public static final String MESSAGE_CONSTRAINTS = "Experience in years has to be an unsigned (non-negative) number.";
+    public static final String MESSAGE_CONSTRAINTS = "Experience in years has to be an unsigned (non-negative) number "
+            + "that is less than 101 (max of 100).";
 
     public final double experienceInYears;
-    public final String value;
 
     /**
      * Constructs an {@code Experience}.
@@ -22,7 +22,6 @@ public class Experience {
     public Experience(String experience) {
         requireNonNull(experience);
         checkArgument(isValidExperience(experience), MESSAGE_CONSTRAINTS);
-        value = experience;
         experienceInYears = Double.parseDouble(experience);
     }
 
@@ -30,13 +29,15 @@ public class Experience {
      * Returns if a given String represents valid number of years of experience.
      */
     public static boolean isValidExperience(String test) {
+        requireNonNull(test);
         double experience;
+        test = test.strip();
         try {
             experience = Double.parseDouble(test);
         } catch (NumberFormatException exception) {
             return false;
         }
-        return experience >= 0;
+        return experience >= 0 && experience < 101;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/information/Salary.java
+++ b/src/main/java/seedu/address/model/information/Salary.java
@@ -9,9 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Salary {
 
-    public static final String MESSAGE_CONSTRAINTS = "Salary has to be an unsigned (non-negative) number.";
+    public static final String MESSAGE_CONSTRAINTS = "Salary has to be an unsigned (non-negative) integer "
+            + "that is less than 1 billion (max of 999,999,999).";
 
-    public final double salary;
+    public final int salary;
 
     /**
      * Constructs an {@code Salary}.
@@ -21,20 +22,22 @@ public class Salary {
     public Salary(String salary) {
         requireNonNull(salary);
         checkArgument(isValidSalary(salary), MESSAGE_CONSTRAINTS);
-        this.salary = Double.parseDouble(salary);
+        this.salary = Integer.parseInt(salary);
     }
 
     /**
      * Returns if a given String represents valid amount of salary.
      */
     public static boolean isValidSalary(String test) {
-        double salaryAmount;
+        requireNonNull(test);
+        int salaryAmount;
+        test = test.strip();
         try {
-            salaryAmount = Double.parseDouble(test);
+            salaryAmount = Integer.parseInt(test);
         } catch (NumberFormatException exception) {
             return false;
         }
-        return salaryAmount >= 0;
+        return salaryAmount >= 0 && salaryAmount < 1000000000;
     }
 
     @Override
@@ -51,6 +54,6 @@ public class Salary {
 
     @Override
     public int hashCode() {
-        return Double.valueOf(salary).hashCode();
+        return Integer.valueOf(salary).hashCode();
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -78,7 +78,7 @@ class JsonAdaptedPerson {
         isBlacklisted = source.getBlacklistStatus().toString();
         address = source.getAddressOptional().map(address -> address.value).orElse(null);
         urlLink = source.getUrlLinkOptional().map(link -> link.value).orElse(null);
-        salary = source.getSalaryOptional().map(sal -> sal.toString()).orElse(null);
+        salary = source.getSalaryOptional().map(Salary::toString).orElse(null);
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -61,12 +61,12 @@ public class PersonCard extends UiPart<Region> {
         personName.setText(person.getName().fullName);
         personPhone.setText(person.getPhone().value);
         personEmail.setText(person.getEmail().value);
-        personExperience.setText(person.getExperience().toString() + " years");
+        personExperience.setText(String.format("%.1f years", person.getExperience().experienceInYears));
         personDateOfApplication.setText(person.getDateOfApplication().dateString);
         personBlacklistStatus.setText(person.getBlacklistStatus().isBlacklisted ? "Blacklisted" : "Not Blacklisted");
         person.getAddressOptional().ifPresent(address -> personAddress.setText(address.value));
         person.getUrlLinkOptional().ifPresent(link -> personUrlLink.setText(link.value));
-        person.getSalaryOptional().ifPresent(sal -> personSalary.setText(String.format("$%.0f", sal.salary)));
+        person.getSalaryOptional().ifPresent(sal -> personSalary.setText("$" + sal.toString()));
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> personTags.getChildren().add(new Label(tag.tagName + " ")));

--- a/src/test/java/seedu/address/model/information/DateTest.java
+++ b/src/test/java/seedu/address/model/information/DateTest.java
@@ -34,11 +34,14 @@ public class DateTest {
         assertFalse(Date.isValidDate("12/12/12")); // date with slash
         assertFalse(Date.isValidDate("3 July 2020")); // date with words
         assertFalse(Date.isValidDate("01-01-2020")); // date with yyyy
+        assertFalse(Date.isValidDate("31-02-20")); // date that does not exist
+        assertFalse(Date.isValidDate("35-12-20")); // date that does not exist
 
         // valid date
         assertTrue(Date.isValidDate("12-12-12")); // date with dashes
         assertTrue(Date.isValidDate("1-1-20")); // date with 1 day and 1 month number
         assertTrue(Date.isValidDate("   11-11-11   ")); // date with whitespace
+        assertTrue(Date.isValidDate("   29-02-20   ")); // leap year date that is valid
     }
 
     @Test

--- a/src/test/java/seedu/address/model/information/ExperienceTest.java
+++ b/src/test/java/seedu/address/model/information/ExperienceTest.java
@@ -33,10 +33,12 @@ public class ExperienceTest {
         assertFalse(Experience.isValidExperience("phone")); // non-numeric
         assertFalse(Experience.isValidExperience("9011p041")); // alphabets within digits
         assertFalse(Experience.isValidExperience("-100")); // negative number
+        assertFalse(Experience.isValidExperience("101")); // number more that 100
+        assertFalse(Experience.isValidExperience("Infinity")); // infinity
 
         // valid experience
         assertTrue(Experience.isValidExperience("0")); // zero
         assertTrue(Experience.isValidExperience("9")); // positive
-        assertTrue(Experience.isValidExperience("  8  ")); // positive with whitespace
+        assertTrue(Experience.isValidExperience("    9    ")); // valid number with whitespace
     }
 }

--- a/src/test/java/seedu/address/model/information/ExperienceTest.java
+++ b/src/test/java/seedu/address/model/information/ExperienceTest.java
@@ -33,7 +33,7 @@ public class ExperienceTest {
         assertFalse(Experience.isValidExperience("phone")); // non-numeric
         assertFalse(Experience.isValidExperience("9011p041")); // alphabets within digits
         assertFalse(Experience.isValidExperience("-100")); // negative number
-        assertFalse(Experience.isValidExperience("101")); // number more that 100
+        assertFalse(Experience.isValidExperience("100.1")); // number more that 100
         assertFalse(Experience.isValidExperience("Infinity")); // infinity
 
         // valid experience

--- a/src/test/java/seedu/address/model/information/SalaryTest.java
+++ b/src/test/java/seedu/address/model/information/SalaryTest.java
@@ -20,7 +20,7 @@ public class SalaryTest {
     }
 
     @Test
-    public void isValidUrlLink() {
+    public void isValidSalary() {
         // null salary
         assertThrows(NullPointerException.class, () -> Salary.isValidSalary(null));
 
@@ -31,12 +31,14 @@ public class SalaryTest {
         assertFalse(Salary.isValidSalary("google")); // alphabets
         assertFalse(Salary.isValidSalary("9011p041")); // alphabets within digits
         assertFalse(Salary.isValidSalary("8,000")); // numbers with comma
+        assertFalse(Salary.isValidSalary("Infinity")); // numbers more than 1 billion
+        assertFalse(Salary.isValidSalary("1000000001")); // numbers more than 1 billion
+        assertFalse(Salary.isValidSalary("2000.5")); // numbers with decimal
 
         // valid salary
         assertTrue(Salary.isValidSalary("0")); // 0
-        assertTrue(Salary.isValidSalary("  0   ")); // 0 with whitespace
-        assertTrue(Salary.isValidSalary("8000")); // positive number
-        assertTrue(Salary.isValidSalary("  8888   ")); // positive number with whitespace
+        assertTrue(Salary.isValidSalary("8000")); // positive number less than 1 billion
+        assertTrue(Salary.isValidSalary("    8000     ")); // valid number with whitespace
     }
 }
 

--- a/src/test/java/seedu/address/model/information/comparator/PersonExpectedSalaryComparatorTest.java
+++ b/src/test/java/seedu/address/model/information/comparator/PersonExpectedSalaryComparatorTest.java
@@ -41,7 +41,7 @@ public class PersonExpectedSalaryComparatorTest {
 
     @Test
     public void testGreaterThan() {
-        Person firstPerson = new PersonBuilder().withSalary("1000.0").build();
+        Person firstPerson = new PersonBuilder().withSalary("1000").build();
         Person secondPerson = new PersonBuilder().withSalary("500").build();
         int result = expectedSalaryComparator.compare(firstPerson, secondPerson);
         assertEquals(result, 1);

--- a/src/test/java/seedu/address/model/information/predicate/PersonSalaryContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/information/predicate/PersonSalaryContainsKeywordsPredicateTest.java
@@ -46,13 +46,13 @@ public class PersonSalaryContainsKeywordsPredicateTest {
 
         // Exact Matching
         PersonSalaryContainsKeywordsPredicate predicate = new PersonSalaryContainsKeywordsPredicate(
-                Arrays.asList("3000.69"));
-        assertTrue(predicate.test(new PersonBuilder().withSalary("3000.69").build()));
+                Arrays.asList("3000"));
+        assertTrue(predicate.test(new PersonBuilder().withSalary("3000").build()));
 
         // Zero keywords
         predicate =
                 new PersonSalaryContainsKeywordsPredicate(Collections.emptyList());
-        assertTrue(predicate.test(new PersonBuilder().withSalary("3000.69").build()));
+        assertTrue(predicate.test(new PersonBuilder().withSalary("3000").build()));
     }
 
     @Test
@@ -61,20 +61,20 @@ public class PersonSalaryContainsKeywordsPredicateTest {
         // One keyword containing
         PersonSalaryContainsKeywordsPredicate predicate = new PersonSalaryContainsKeywordsPredicate(
                 Collections.singletonList("3000"));
-        assertFalse(predicate.test(new PersonBuilder().withSalary("3000.69").build()));
+        assertFalse(predicate.test(new PersonBuilder().withSalary("3001").build()));
 
         // Only one matching keyword, the rest does not match
         predicate = new PersonSalaryContainsKeywordsPredicate(
-                Arrays.asList("2154.77", "3000.69"));
-        assertFalse(predicate.test(new PersonBuilder().withSalary("3000.69").build()));
+                Arrays.asList("2154", "3000"));
+        assertFalse(predicate.test(new PersonBuilder().withSalary("3000").build()));
 
         // Non-matching keyword
-        predicate = new PersonSalaryContainsKeywordsPredicate(Arrays.asList("2154.77"));
-        assertFalse(predicate.test(new PersonBuilder().withSalary("3000.69").build()));
+        predicate = new PersonSalaryContainsKeywordsPredicate(Arrays.asList("2154"));
+        assertFalse(predicate.test(new PersonBuilder().withSalary("3000").build()));
 
         // Keywords match phone but does not match address
         predicate = new PersonSalaryContainsKeywordsPredicate(
-                Arrays.asList("12345", "2122.88"));
-        assertFalse(predicate.test(new PersonBuilder().withPhone("12345").withSalary("3000.69").build()));
+                Arrays.asList("12345", "2122"));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345").withSalary("3000").build()));
     }
 }


### PR DESCRIPTION
Bug fixes relating to Date, Salary, Experience classes

Closes #173 : Edit error (usage) message to be clearer in Date
Closes #174 : The example date in the message was incorrect. It has been corrected.
Closes #187 : The formatter was set on lenient mode by default. It has been changed to strict mode.
Closes #198 : Same as #187 
Closes #211 : Set maximum value for Experience to be 100.
Closes #212 : Set maximum value for Salary to be 999,999,999
Closes #213 : Change Salary to only accept integers (no more floats) now since salary typically does not include cents.